### PR TITLE
[fix #2] Fix headers on delete call

### DIFF
--- a/resources/js/LarecipeSwagger.vue
+++ b/resources/js/LarecipeSwagger.vue
@@ -94,7 +94,7 @@ export default {
         run() {
             let call = null
             
-            if(this.method == "get") {
+            if(["get", "delete"].includes(this.method)) {
                 call = axios[this.method](this.fullUrl, {params: this.params, headers: this.headers})
             }else {
                 call = axios[this.method](this.fullUrl, this.params, {headers: this.headers})


### PR DESCRIPTION
The axios delete alias has the same signature of the `get` alias.
See https://github.com/axios/axios#request-method-aliases for more information.